### PR TITLE
Remove block for array and object attr types

### DIFF
--- a/src/Rest/RestConfiguration.php
+++ b/src/Rest/RestConfiguration.php
@@ -11,6 +11,9 @@ use As3\Modlr\Util\Validator;
  */
 class RestConfiguration
 {
+    /**
+     * @var string
+     */
     private $rootEndpoint = '/';
 
     /**

--- a/src/Util/EntityUtility.php
+++ b/src/Util/EntityUtility.php
@@ -210,12 +210,6 @@ class EntityUtility
                 }
             }
 
-            // @todo Determine how to validate object and array
-            $todo = ['object', 'array'];
-            if (in_array($attribute->dataType, $todo)) {
-                throw MetadataException::invalidMetadata($metadata->type, 'NYI: Object and array attribute types still need expanding!!');
-            }
-
             if (true === $attribute->isCalculated()) {
                 if (false === class_exists($attribute->calculated['class']) || false === method_exists($attribute->calculated['class'], $attribute->calculated['method'])) {
                     throw MetadataException::invalidMetadata($metadata->type, sprintf('The attribute field "%s" is calculated, but was unable to find method "%s:%s"', $attribute->key, $attribute->calculated['class'], $attribute->calculated['method']));


### PR DESCRIPTION
Array (collection) and object (hash) attributes are no longer blocked.

Originally, object attributes were going to be treated as "embedded" models. This will no longer be the case, and objects will be treated as a plain-old associative array. Embedded attributes will be handled separately. 

Closes #31 