### PR TITLE
Add not saved properties

### DIFF
--- a/src/Metadata/Driver/YamlFileDriver.php
+++ b/src/Metadata/Driver/YamlFileDriver.php
@@ -224,7 +224,6 @@ final class YamlFileDriver extends AbstractFileDriver
 
             $attribute = new Metadata\AttributeMetadata($key, $mapping['type'], $this->isMixin($metadata));
 
-            // @todo Handle complex attribute types.
             if (isset($mapping['description'])) {
                 $attribute->description = $mapping['description'];
             }
@@ -245,6 +244,10 @@ final class YamlFileDriver extends AbstractFileDriver
                 $attribute->setAutocomplete(true);
             } else if (isset($mapping['search']['store'])) {
                 $attribute->setSearchProperty(true);
+            }
+
+            if (isset($mapping['save'])) {
+                $attribute->enableSave($mapping['save']);
             }
 
             $metadata->addAttribute($attribute);
@@ -311,6 +314,10 @@ final class YamlFileDriver extends AbstractFileDriver
 
             if (isset($mapping['search']['store'])) {
                 $relationship->setSearchProperty(true);
+            }
+
+            if (isset($mapping['save'])) {
+                $attribute->enableSave($mapping['save']);
             }
 
             $metadata->addRelationship($relationship);

--- a/src/Metadata/Driver/YamlFileDriver.php
+++ b/src/Metadata/Driver/YamlFileDriver.php
@@ -317,7 +317,7 @@ final class YamlFileDriver extends AbstractFileDriver
             }
 
             if (isset($mapping['save'])) {
-                $attribute->enableSave($mapping['save']);
+                $relationship->enableSave($mapping['save']);
             }
 
             $metadata->addRelationship($relationship);

--- a/src/Metadata/FieldMetadata.php
+++ b/src/Metadata/FieldMetadata.php
@@ -13,13 +13,6 @@ use As3\Modlr\Exception\MetadataException;
 abstract class FieldMetadata
 {
     /**
-     * The field key.
-     *
-     * @var string
-     */
-    public $key;
-
-    /**
      * A friendly description of the field.
      *
      * @var string
@@ -27,11 +20,25 @@ abstract class FieldMetadata
     public $description;
 
     /**
+     * The field key.
+     *
+     * @var string
+     */
+    public $key;
+
+    /**
      * Determines if this field came from a mixin.
      *
      * @var bool
      */
     public $mixin;
+
+    /**
+     * Whether this property should be persisted.
+     *
+     * @var bool
+     */
+    public $save = true;
 
     /**
      * Determines whether this propety is stored in search.
@@ -54,6 +61,18 @@ abstract class FieldMetadata
     }
 
     /**
+     * Enables or disables saving of this property.
+     *
+     * @param   bool    $bit
+     * @return  self
+     */
+    public function enableSave($bit = true)
+    {
+        $this->save = (bool) $bit;
+        return $this;
+    }
+
+    /**
      * Gets the field key.
      *
      * @return  string
@@ -61,6 +80,16 @@ abstract class FieldMetadata
     public function getKey()
     {
         return $this->key;
+    }
+
+    /**
+     * Determines whether this propety is stored in search.
+     *
+     * @return  bool
+     */
+    public function isSearchProperty()
+    {
+        return $this->searchProperty;
     }
 
     /**
@@ -76,13 +105,13 @@ abstract class FieldMetadata
     }
 
     /**
-     * Determines whether this propety is stored in search.
+     * Whether this property should be saved/persisted to the data layer.
      *
      * @return  bool
      */
-    public function isSearchProperty()
+    public function shouldSave()
     {
-        return $this->searchProperty;
+        return $this->save;
     }
 
     /**


### PR DESCRIPTION
Properties (attributes and relationships) can now be marked as save = false. This prevents the property from being stored by the storage layer.

Closes #27