### PR TITLE
Hotfix: greedy default values

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -689,7 +689,7 @@ class Model
     {
         // Set defaults for each attribute.
         foreach ($this->getMetadata()->getAttributes() as $key => $attrMeta) {
-            if (!isset($attrMeta->defaultValue)) {
+            if (!isset($attrMeta->defaultValue) || isset($attributes[$key])) {
                 continue;
             }
             $attributes[$key] = $this->convertAttributeValue($key, $attrMeta->defaultValue);
@@ -697,6 +697,9 @@ class Model
 
         // Set defaults for the entire entity.
         foreach ($this->getMetadata()->defaultValues as $key => $value) {
+            if (isset($attributes[$key])) {
+                continue;
+            }
             $attributes[$key] = $this->convertAttributeValue($key, $value);
         }
         return $attributes;

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.1.2';
-    const ID = 102;
+    const VERSION = '0.1.3';
+    const ID = 103;
     const MAJOR = 0;
     const MINOR = 1;
-    const PATCH = 2;
+    const PATCH = 3;
     const EXTRA = '';
 }


### PR DESCRIPTION
A model's default attribute value was overwriting a set value. This ensures that if an attribute value has been specifically set, the default value is not applied.