### PR TITLE
Move persister and search specific metadata loading

### DIFF
--- a/src/Metadata/Driver/YamlFileDriver.php
+++ b/src/Metadata/Driver/YamlFileDriver.php
@@ -153,18 +153,7 @@ final class YamlFileDriver extends AbstractFileDriver
         $persisterKey = isset($mapping['key']) ? $mapping['key'] : null;
         $factory = $this->getPersistenceMetadataFactory($persisterKey);
 
-        $persistence = $factory->getNewInstance();
-
-        // @todo Everything here must be done in the MongoDB factory!!!
-        $persistence->persisterKey = $persisterKey;
-
-        if (isset($mapping['db'])) {
-            $persistence->db = $mapping['db'];
-        }
-
-        if (isset($mapping['collection'])) {
-            $persistence->collection = $mapping['collection'];
-        }
+        $persistence = $factory->createInstance($mapping);
 
         $metadata->setPersistence($persistence);
         return $metadata;
@@ -180,20 +169,14 @@ final class YamlFileDriver extends AbstractFileDriver
     protected function setSearch(Metadata\EntityMetadata $metadata, array $mapping)
     {
         $clientKey = isset($mapping['key']) ? $mapping['key'] : null;
+        if (null === $clientKey) {
+            // Search is not enabled for this model.
+            return $metadata;
+        }
+
         $factory = $this->getSearchMetadataFactory($clientKey);
 
-        $search = $factory->getNewInstance();
-
-        // @todo Everything here must be done in the Elastic factory!!!
-        $search->clientKey = $clientKey;
-
-        if (isset($mapping['index'])) {
-            $search->index = $mapping['index'];
-        }
-
-        if (isset($mapping['type'])) {
-            $search->type = $mapping['type'];
-        }
+        $search = $factory->createInstance($mapping);
 
         $metadata->setSearch($search);
         return $metadata;
@@ -202,7 +185,6 @@ final class YamlFileDriver extends AbstractFileDriver
     /**
      * Sets the entity attribute metadata from the metadata mapping.
      *
-     * @todo    Add support for complex attributes, like arrays and objects.
      * @param   Metadata\Interfaces\AttributeInterface  $metadata
      * @param   array                                   $attrMapping
      * @return  Metadata\EntityMetadata
@@ -369,21 +351,9 @@ final class YamlFileDriver extends AbstractFileDriver
             $mapping['entity']['persistence'] = [];
         }
 
-        if (!isset($mapping['entity']['persistence']['key'])) {
-            // @todo Should this be defaulted here, or handled differently?
-            $mapping['entity']['persistence']['key'] = 'mongodb';
-        }
-
         if (!isset($mapping['entity']['search']) || !is_array($mapping['entity']['search'])) {
             $mapping['entity']['search'] = [];
         }
-
-        if (!isset($mapping['entity']['search']['key'])) {
-            // @todo Should this be defaulted here, or handled differently?
-            // @todo Is it ever possible to not have a search client, but still specify search on a property?
-            $mapping['entity']['search']['key'] = 'elastic';
-        }
-
         return $mapping;
     }
 

--- a/src/Metadata/Interfaces/StorageMetadataFactoryInterface.php
+++ b/src/Metadata/Interfaces/StorageMetadataFactoryInterface.php
@@ -6,18 +6,18 @@ use As3\Modlr\Metadata\EntityMetadata;
 
 /**
  * Creates Storage Layer Metadata (persistence/search) instances in the implementing format.
- * Is used by the metadata driver and/or factory for creating new instances and validation.
+ * Is used by the metadata driver and/or factory for creating new instances, setting values, and performing validation.
  *
  * @author Jacob Bare <jacob.bare@gmail.com>
  */
 interface StorageMetadataFactoryInterface
 {
     /**
-     * Gets a new and empty Storage Layer Metadata object.
+     * Creates a new instance based on a driver mapping.
      *
      * @return  StorageLayerInterface
      */
-    public function getNewInstance();
+    public function createInstance(array $mapping);
 
     /**
      * Handles additional metadata operations on the Factory load.

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -138,18 +138,10 @@ class MetadataFactory implements MetadataFactoryInterface
             $this->entityUtil->validateMetadata($hierType, $loaded, $this);
 
             // Handle persistence specific loading and validation.
-            $persisterKey = $loaded->persistence->getKey();
-            $persistenceFactory = $this->driver->getPersistenceMetadataFactory($persisterKey);
-
-            $persistenceFactory->handleLoad($loaded);
-            $persistenceFactory->handleValidate($loaded);
+            $this->loadPersistenceMetadata($loaded);
 
             // Handle search specific loading and validation.
-            $clientKey = $loaded->search->getKey();
-            $searchFactory = $this->driver->getSearchMetadataFactory($clientKey);
-
-            $searchFactory->handleLoad($loaded);
-            $searchFactory->handleValidate($loaded);
+            $this->loadSearchMetadata($loaded);
 
             $this->mergeMetadata($metadata, $loaded);
             $this->doPutMetadata($loaded);
@@ -255,6 +247,41 @@ class MetadataFactory implements MetadataFactoryInterface
             throw new InvalidArgumentException(sprintf('This resource only supports resources of type "%s" - resource type "%s" was provided', $parentType, $childType));
         }
         return true;
+    }
+
+    /**
+     * Handles persistence specific metadata loading.
+     *
+     * @param   EntityMetadata  $metadata
+     * @return  EntityMetadata
+     */
+    private function loadPersistenceMetadata(EntityMetadata $metadata)
+    {
+        $persisterKey = $metadata->persistence->getKey();
+        $persistenceFactory = $this->driver->getPersistenceMetadataFactory($persisterKey);
+
+        $persistenceFactory->handleLoad($metadata);
+        $persistenceFactory->handleValidate($metadata);
+        return $metadata;
+    }
+
+    /**
+     * Handles search specific metadata loading.
+     *
+     * @param   EntityMetadata  $metadata
+     * @return  EntityMetadata
+     */
+    private function loadSearchMetadata(EntityMetadata $metadata)
+    {
+        if (false === $metadata->isSearchEnabled()) {
+            return $metadata;
+        }
+        $clientKey = $metadata->search->getKey();
+        $searchFactory = $this->driver->getSearchMetadataFactory($clientKey);
+
+        $searchFactory->handleLoad($metadata);
+        $searchFactory->handleValidate($metadata);
+        return $metadata;
     }
 
     /**

--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -117,7 +117,6 @@ class Store
      * Searches for records (via the search layer) for a specific type, attribute, and value.
      * Uses the autocomplete logic to fullfill the request.
      *
-     * @todo    Validate that search is enabled for the model and its attribute.
      * @todo    Determine if full models should be return, or only specific fields.
      *          Autocompleters needs to be fast. If only specific fields are returned, do we need to exclude nulls in serialization?
      * @todo    Is search enabled for all models, by default, where everything is stored?
@@ -130,8 +129,10 @@ class Store
     public function searchAutocomplete($typeKey, $attributeKey, $searchValue)
     {
         $metadata = $this->getMetadataForType($typeKey);
-        $models = [];
-        return new Collection($metadata, $this, $models);
+        if (false === $metadata->isSearchEnabled()) {
+            throw StoreException::badRequest(sprintf('Search is not enabled for model type "%s"', $metadata->type));
+        }
+        return new Collection($metadata, $this, []);
     }
 
     /**


### PR DESCRIPTION
- Search and persistence specific properties were being set by the root driver - this should not have been the case. Instead, each sub-library should handle it's own loading. This addresses that concern.
- Add a check for the existence of search in `EntityMetadata`, as this is optional
- Ensure the `Store` checks for enabled search for a `Model`
- Clean up `EntityMetadata` class