### PR TITLE
Add core query support

### DIFF
--- a/src/Api/AbstractAdapter.php
+++ b/src/Api/AbstractAdapter.php
@@ -88,6 +88,16 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritDoc}
      */
+    public function findQuery($typeKey, array $criteria, array $fields = [], array $sort = [], array $inclusions =[], $offset = 0, $limit = 0)
+    {
+        $collection = $this->getStore()->findQuery($typeKey, $criteria, $fields, $sort, $offset, $limit);
+        $payload = $this->serializeCollection($collection);
+        return $this->createRestResponse(200, $payload);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function findRelationship($typeKey, $identifier, $fieldKey)
     {
         $model = $this->getStore()->find($typeKey, $identifier);

--- a/src/Api/AdapterInterface.php
+++ b/src/Api/AdapterInterface.php
@@ -53,6 +53,20 @@ interface AdapterInterface
     public function findAll($typeKey, array $identifiers = []); //, array $pagination = [], array $fields = [], array $inclusions = [], array $sort = []);
 
     /**
+     * Queries records based on a provided set of criteria.
+     *
+     * @param   string      $typeKey    The model type.
+     * @param   array       $criteria   The query criteria.
+     * @param   array       $fields     Fields to include/exclude.
+     * @param   array       $sort       The sort criteria.
+     * @param   array       $inclusions The inclusion criteria for side-loading related models.
+     * @param   int         $offset     The starting offset, aka the number of Models to skip.
+     * @param   int         $limit      The number of Models to limit.
+     * @return  Collection
+     */
+    public function findQuery($typeKey, array $criteria, array $fields = [], array $sort = [], array $inclusions =[], $offset = 0, $limit = 0);
+
+    /**
      * Creates a new model.
      *
      * @param   string              $typeKey

--- a/src/Metadata/EntityMetadata.php
+++ b/src/Metadata/EntityMetadata.php
@@ -29,6 +29,11 @@ class EntityMetadata implements AttributeInterface, RelationshipInterface, Merge
     const ID_TYPE = 'string';
 
     /**
+     * The model type key.
+     */
+    const TYPE_KEY = 'type';
+
+    /**
      * Whether this class is abstract.
      *
      * @var bool

--- a/src/Persister/PersisterInterface.php
+++ b/src/Persister/PersisterInterface.php
@@ -52,6 +52,20 @@ interface PersisterInterface
     public function retrieve(EntityMetadata $metadata, $identifier, Store $store);
 
     /**
+     * Queries for multiple records based on a provided set of criteria.
+     *
+     * @param   EntityMetadata      $metadata   The metadata for the model.
+     * @param   Store               $store      The model store.
+     * @param   array               $criteria   The query criteria.
+     * @param   array               $fields     Fields to include/exclude.
+     * @param   array               $sort       The sort criteria.
+     * @param   int                 $offset     The starting offset, aka the number of Models to skip.
+     * @param   int                 $limit      The number of Models to limit.
+     * @return  Collection
+     */
+    public function query(EntityMetadata $metadata, Store $store, array $criteria, array $fields = [], array $sort = [], $offset = 0, $limit = 0);
+
+    /**
      * Retrieves inverse record references for the provided owner, based on the related metadata, identifiers, and field.
      *
      * @param   EntityMetadata  $owner      The metadata for the owning model.


### PR DESCRIPTION
The core interfaces and the `Store` now supports querying for Models based on a set of criteria.