### PR TITLE
Ensure true/false strings use bool equivelant

### DIFF
--- a/src/DataTypes/Types/BooleanType.php
+++ b/src/DataTypes/Types/BooleanType.php
@@ -17,6 +17,12 @@ class BooleanType implements TypeInterface
         if (null === $value) {
             return $value;
         }
+        if ('true' === strtolower($value)) {
+            return true;
+        }
+        if ('false' === strtolower($value)) {
+            return false;
+        }
         return (Boolean) $value;
     }
 }

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.2.4';
-    const ID = 204;
+    const VERSION = '0.2.5';
+    const ID = 205;
     const MAJOR = 0;
     const MINOR = 2;
-    const PATCH = 4;
+    const PATCH = 5;
     const EXTRA = '';
 }


### PR DESCRIPTION
Passing a string of true or false will ensure the value is loaded as a boolean true/false.