### PR TITLE
Support Symfony3 modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "symfony/http-foundation": "^2.6"
+        "symfony/http-foundation": "^2.6 || ^3.0"
     },
     "suggest": {
         "as3/modlr-api-jsonapiorg": "Provides jsonapi.org REST API spec and functionality.",


### PR DESCRIPTION
This PR bumps the hard version constraint to support either the 2.6+ series or 3.0+ of symfony/http-foundation.