### PR TITLE
Add method to Store to get all available types

### DIFF
--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -91,6 +91,16 @@ class Store
     }
 
     /**
+     * Returns the available type keys from the MetadataFactory
+     *
+     * @return  array
+     */
+    public function getTypes()
+    {
+        return $this->mf->getAllTypeNames();
+    }
+
+    /**
      * Finds all records (or filtered by specific identifiers) for a type.
      *
      * @todo    Add sorting and pagination (limit/skip).

--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -95,7 +95,7 @@ class Store
      *
      * @return  array
      */
-    public function getTypes()
+    public function getModelTypes()
     {
         return $this->mf->getAllTypeNames();
     }


### PR DESCRIPTION
Allows access to `MetadataFactory::getAllTypeNames()` (which is already public) from outside the `Store` itself.

Allows external perspective into what model types have been loaded/are available.