### PR TITLE
Dispatch postLoad metadata event

### DIFF
--- a/src/Metadata/Events.php
+++ b/src/Metadata/Events.php
@@ -9,6 +9,5 @@ namespace As3\Modlr\Metadata;
  */
 class Events
 {
-    const preLoad   = 'preLoad';
     const postLoad  = 'postLoad';
 }

--- a/src/Metadata/Events.php
+++ b/src/Metadata/Events.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace As3\Modlr\Metadata;
+
+/**
+ * Store event name constants.
+ *
+ * @author Josh Worden <solocommand@gmail.com>
+ */
+class Events
+{
+    const preLoad   = 'preLoad';
+    const postLoad  = 'postLoad';
+}

--- a/src/Metadata/Events/MetadataArguments.php
+++ b/src/Metadata/Events/MetadataArguments.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace As3\Modlr\Metadata\Events;
+
+use As3\Modlr\Events\EventArguments;
+use As3\Modlr\Metadata\EntityMetadata;
+
+/**
+ * Store event constants.
+ *
+ * @author Josh Worden <solocommand@gmail.com>
+ */
+class MetadataArguments extends EventArguments
+{
+    /**
+     * @var EntityMetadata
+     */
+    private $metadata;
+
+    /**
+     * Constructor.
+     *
+     * @param   EntityMetadata   $metadata
+     */
+    public function __construct(EntityMetadata $metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * Gets the metadata.
+     *
+     * @return  EntityMetadata
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.2.6';
-    const ID = 206;
+    const VERSION = '0.2.7';
+    const ID = 207;
     const MAJOR = 0;
     const MINOR = 2;
-    const PATCH = 6;
+    const PATCH = 7;
     const EXTRA = '';
 }


### PR DESCRIPTION
Dispatches a `postLoad` event within the `MetadataFactory` to allow event subscribers to make modifications to `EntityMetadata` before it is cached -- for example, to modify the database name as needed by the application.