### PR TITLE
Changed metadata event name to prevent conflict

### DIFF
--- a/src/Metadata/Events.php
+++ b/src/Metadata/Events.php
@@ -9,5 +9,5 @@ namespace As3\Modlr\Metadata;
  */
 class Events
 {
-    const postLoadMetadata  = 'postLoadMetadata';
+    const onMetadataLoad  = 'onMetadataLoad';
 }

--- a/src/Metadata/Events.php
+++ b/src/Metadata/Events.php
@@ -9,5 +9,5 @@ namespace As3\Modlr\Metadata;
  */
 class Events
 {
-    const postLoad  = 'postLoad';
+    const postLoadMetadata  = 'postLoadMetadata';
 }

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -175,7 +175,7 @@ class MetadataFactory implements MetadataFactoryInterface
     private function dispatchMetadataEvent(EntityMetadata $metadata)
     {
         $metadataArgs = new Events\MetadataArguments($metadata);
-        $this->dispatcher->dispatch(Events::postLoad, $metadataArgs);
+        $this->dispatcher->dispatch(Events::postLoadMetadata, $metadataArgs);
     }
 
     /**

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -175,7 +175,7 @@ class MetadataFactory implements MetadataFactoryInterface
     private function dispatchMetadataEvent(EntityMetadata $metadata)
     {
         $metadataArgs = new Events\MetadataArguments($metadata);
-        $this->dispatcher->dispatch(Events::postLoadMetadata, $metadataArgs);
+        $this->dispatcher->dispatch(Events::onMetadataLoad, $metadataArgs);
     }
 
     /**

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.2.7';
-    const ID = 207;
+    const VERSION = '0.2.8';
+    const ID = 208;
     const MAJOR = 0;
     const MINOR = 2;
-    const PATCH = 7;
+    const PATCH = 8;
     const EXTRA = '';
 }


### PR DESCRIPTION
postLoad was already in use by the store.