### PR TITLE
Fix bug loadCollection was not returning array

### DIFF
--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -392,7 +392,7 @@ class Store
         $identifiers = $collection->getIdentifiers();
         if (empty($identifiers)) {
             // Nothing to query.
-            return $collection;
+            return [];
         }
         if ($collection instanceof InverseCollection) {
             $records = $this->retrieveInverseRecords($collection->getOwner()->getType(), $collection->getType(), $collection->getIdentifiers(), $collection->getQueryField());

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.2.8';
-    const ID = 208;
+    const VERSION = '0.2.9';
+    const ID = 209;
     const MAJOR = 0;
     const MINOR = 2;
-    const PATCH = 8;
+    const PATCH = 9;
     const EXTRA = '';
 }


### PR DESCRIPTION
The `loadCollection` method must return an array of Models. If the collection was empty, the code was previously returning the passed collection, and not returning an array.