### PR TITLE
Add support for preQuery events

### DIFF
--- a/src/Store/Events.php
+++ b/src/Store/Events.php
@@ -24,4 +24,6 @@ class Events
 
     const preDelete  = 'preDelete';
     const postDelete = 'postDelete';
+
+    const preQuery   = 'preQuery';
 }

--- a/src/Store/Events/PreQueryArguments.php
+++ b/src/Store/Events/PreQueryArguments.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace As3\Modlr\Store\Events;
+
+use As3\Modlr\Events\EventArguments;
+use As3\Modlr\Metadata\EntityMetadata;
+use As3\Modlr\Persister\PersisterInterface;
+use As3\Modlr\Store\Store;
+
+/**
+ * Pre-query event args.
+ *
+ * @author Jacob Bare <jacob.bare@gmail.com>
+ */
+class PreQueryArguments extends EventArguments
+{
+    /**
+     * @var array
+     */
+    private $criteria;
+
+    /**
+     * @var EntityMetadata
+     */
+    private $metadata;
+
+    /**
+     * @var PersisterInterface
+     */
+    private $persister;
+
+    /**
+     * @var Store
+     */
+    private $store;
+
+    /**
+     * Constructor.
+     *
+     * @param   Store               $store
+     * @param   PersisterInterface  $persister
+     * @param   array               $criteria
+     */
+    public function __construct(EntityMetadata $metadata, Store $store, PersisterInterface $persister, array &$criteria)
+    {
+        $this->metadata = $metadata;
+        $this->store = $store;
+        $this->persister = $persister;
+        $this->criteria = &$criteria;
+    }
+
+    /**
+     * Gets the metadata.
+     *
+     * @return  EntityMetadata
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * Gets the persister.
+     *
+     * @return  PersisterInterface
+     */
+    public function getPersister()
+    {
+        return $this->persister;
+    }
+
+    /**
+     * Gets the store.
+     *
+     * @return  Store
+     */
+    public function getStore()
+    {
+        return $this->store;
+    }
+
+    /**
+     * Gets the criteria (by reference) so it can be manipulated.
+     *
+     * @return  array
+     */
+    public function &getCriteria()
+    {
+        return $this->criteria;
+    }
+}

--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -16,6 +16,7 @@ use As3\Modlr\Persister\PersisterInterface;
 use As3\Modlr\Persister\RecordSetInterface;
 use As3\Modlr\StorageLayerManager;
 use As3\Modlr\Store\Events\ModelLifecycleArguments;
+use As3\Modlr\Store\Events\PreQueryArguments;
 
 /**
  * Manages models and their persistence.
@@ -139,8 +140,9 @@ class Store
     public function findQuery($typeKey, array $criteria, array $fields = [], array $sort = [], $offset = 0, $limit = 0)
     {
         $metadata = $this->getMetadataForType($typeKey);
-
         $persister = $this->getPersisterFor($typeKey);
+        $this->dispatcher->dispatch(Events::preQuery, new PreQueryArguments($metadata, $this, $persister, $criteria));
+
         $recordSet = $persister->query($metadata, $this, $criteria, $fields, $sort, $offset, $limit);
 
         $models = $this->loadModels($typeKey, $recordSet);

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.3.6';
-    const ID = 306;
+    const VERSION = '0.3.7';
+    const ID = 307;
     const MAJOR = 0;
     const MINOR = 3;
-    const PATCH = 6;
+    const PATCH = 7;
     const EXTRA = '';
 }


### PR DESCRIPTION
The `Store` will now fire a `preQuery` event in `findQuery` before performing the query. This allows event subscribers to manipulate the provided query criteria before sending the request to the persister.