### PR TITLE
Ensure datetimes are evaluated using timestamp

### DIFF
--- a/src/Models/Properties.php
+++ b/src/Models/Properties.php
@@ -74,10 +74,15 @@ abstract class Properties
         }
         $this->clearRemoval($key);
 
-        if ($value === $this->getOriginal($key)) {
+        $original = $this->getOriginal($key);
+        if ($value === $original) {
             $this->clearChange($key);
         } else {
-            $this->current[$key] = $value;
+            if (($value instanceof \DateTime && $original instanceof \DateTime) && ($value->getTimestamp() === $original->getTimestamp())) {
+                $this->clearChange($key);
+            } else {
+                $this->current[$key] = $value;
+            }
         }
         return $this;
     }

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.3.7';
-    const ID = 307;
+    const VERSION = '0.3.8';
+    const ID = 308;
     const MAJOR = 0;
     const MINOR = 3;
-    const PATCH = 7;
+    const PATCH = 8;
     const EXTRA = '';
 }


### PR DESCRIPTION
Previously, DateTime objects were not properly being compared due to timezone differences. Using the DateTime timestamp will correct this.