### PR TITLE
Ensure embeds are applied from mixin definitions

### DIFF
--- a/src/Metadata/Driver/YamlFileDriver.php
+++ b/src/Metadata/Driver/YamlFileDriver.php
@@ -84,6 +84,7 @@ final class YamlFileDriver extends AbstractFileDriver
         $mixin = new Metadata\MixinMetadata($mixinName);
 
         $this->setAttributes($mixin, $mapping['attributes']);
+        $this->setEmbeds($mixin, $mapping['embeds']);
         $this->setRelationships($mixin, $mapping['relationships']);
         return $mixin;
     }

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.3.8';
-    const ID = 308;
+    const VERSION = '0.3.9';
+    const ID = 309;
     const MAJOR = 0;
     const MINOR = 3;
-    const PATCH = 8;
+    const PATCH = 9;
     const EXTRA = '';
 }


### PR DESCRIPTION
Any embeds defined on a mixin were not being applied to the mixin metadata and, due to that, not applied to the model.