### PR TITLE
Prevent infinite recursion of self-referencing embeds

### DIFF
--- a/src/Metadata/Driver/YamlFileDriver.php
+++ b/src/Metadata/Driver/YamlFileDriver.php
@@ -280,7 +280,13 @@ final class YamlFileDriver extends AbstractFileDriver
                 $mapping['entity'] = null;
             }
 
-            $embedMeta = $this->loadMetadataForEmbed($mapping['entity']);
+            if ($metadata instanceof Metadata\EmbedMetadata && $mapping['entity'] === $metadata->name) {
+                // This embed meta is referencing itself as an embed property. As such, do not recreate.
+                // This prevents infinite recursion.
+                $embedMeta = $metadata;
+            } else {
+                $embedMeta = $this->loadMetadataForEmbed($mapping['entity']);
+            }
             if (null === $embedMeta) {
                 continue;
             }

--- a/src/Util/EntityUtility.php
+++ b/src/Util/EntityUtility.php
@@ -235,7 +235,10 @@ class EntityUtility
     {
         foreach ($metadata->getEmbeds() as $key => $embeddedProp) {
             $this->validateMetadataAttributes($embeddedProp->embedMeta, $mf);
-            $this->validateMetadataEmbeds($embeddedProp->embedMeta, $mf);
+            if ($metadata !== $embeddedProp->embedMeta) {
+                // Only re-validate if the embedded prop reference isn't the same as the parent.
+                $this->validateMetadataEmbeds($embeddedProp->embedMeta, $mf);
+            }
         }
         return true;
     }

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.3.17';
-    const ID = 3017;
+    const VERSION = '0.3.18';
+    const ID = 3018;
     const MAJOR = 0;
     const MINOR = 3;
-    const PATCH = 17;
+    const PATCH = 18;
     const EXTRA = '';
 }


### PR DESCRIPTION
If an embed were to reference itself, the YAML driver and validator would be get "stuck" in an infinite loop when loading the metadata for the embed.

Example:

```yaml
# resources/models/foo.yml
foo:
    embeds:
        someEmbed:
            type: one
            entity: some-embed
```
```yaml
# resources/embeds/some-embed.yml
some-embed:
    embeds:
        someEmbed:
            type: one
            entity: some-embed
```

Because the `some-embed` entity was referencing itself, the metadata loading process would infinitely recurse. This has been corrected.