### PR TITLE
Ensure object property changes are tracked

### DIFF
--- a/src/Models/Properties.php
+++ b/src/Models/Properties.php
@@ -75,6 +75,16 @@ abstract class Properties
         $this->clearRemoval($key);
 
         $original = $this->getOriginal($key);
+        
+        if ($value instanceof \stdClass && $original instanceof \stdClass) {
+            if ($value == $original) {
+                $this->clearChange($key);
+            } else {
+                $this->current[$key] = $value;
+            }
+            return $this;
+        }
+        
         if ($value === $original) {
             $this->clearChange($key);
         } else {

--- a/src/Version.php
+++ b/src/Version.php
@@ -9,10 +9,10 @@ namespace As3\Modlr;
  */
 class Version
 {
-    const VERSION = '0.3.19';
-    const ID = 3019;
+    const VERSION = '0.3.20';
+    const ID = 3020;
     const MAJOR = 0;
     const MINOR = 3;
-    const PATCH = 19;
+    const PATCH = 20;
     const EXTRA = '';
 }


### PR DESCRIPTION
Using `===` on `\stdClass` values was too strict. This was causing any model with an `object` attribute type to be reporting as dirty, even when it wasn't.