### PR TITLE
Support prefixes of the REST endpoint

### DIFF
--- a/src/Rest/RestRequest.php
+++ b/src/Rest/RestRequest.php
@@ -118,6 +118,11 @@ class RestRequest
     private $config;
 
     /**
+     * @var string
+     */
+    private $uri;
+
+    /**
      * Constructor.
      *
      * @param   RestConfiguration   $config     The REST configuration.
@@ -128,7 +133,12 @@ class RestRequest
     public function __construct(RestConfiguration $config, $method, $uri, $payload = null)
     {
         $this->config = $config;
+        $this->uri = $uri;
         $this->requestMethod = strtoupper($method);
+
+        if ($this->config->getRootEndpoint() !== $this->getEndpointPrefix()) {
+            $this->config->setRootEndpoint($this->getEndpointPrefix());
+        }
 
         $this->sorting      = $config->getDefaultSorting();
         $this->pagination   = $config->getDefaultPagination();
@@ -153,9 +163,22 @@ class RestRequest
         return sprintf('%s://%s/%s/%s%s',
             $this->getScheme(),
             trim($this->getHost(), '/'),
-            trim($this->config->getRootEndpoint(), '/'),
+            trim($this->getEndpointPrefix(), '/'),
             $this->getEntityType(),
             empty($query) ? '' : sprintf('?%s', $query)
+        );
+    }
+
+    protected function getEndpointPrefix()
+    {
+        $path = parse_url($this->uri)['path'];
+        return substr(
+            $path,
+            0,
+            strrpos(
+                $path,
+                $this->config->getRootEndpoint()
+            ) + strlen($this->config->getRootEndpoint())
         );
     }
 

--- a/src/Rest/RestRequest.php
+++ b/src/Rest/RestRequest.php
@@ -128,7 +128,6 @@ class RestRequest
     public function __construct(RestConfiguration $config, $method, $uri, $payload = null)
     {
         $this->config = $config;
-        $this->uri = $uri;
         $this->requestMethod = strtoupper($method);
 
         $this->sorting      = $config->getDefaultSorting();


### PR DESCRIPTION
If a PHP script (framework/etc) is located under a subdirectory rather than at the root of a domain, PHP's handling of the global request variables gets weird. Specifically, the request_uri is correct, but should have the prefix of script_uri removed from it. This PR allows the modlr API to work if there is a prefix in place.

@zarathustra323 I thought about doing this in as3io/As3ModlrBundle when it is configuring the RestConfiguration in DI, but it unfortunately won't have knowledge of this condition since it's at run-time and not available in the CLI when the cache is generated.

For a concrete example:
A Symfony project is installed at `https://my.domain.com/cool-project`, configured with a `rest_endpoint` of `/api/1.0`.
A request to `https://my.domain.com/cool-project/api/1.0/model-name/model-id` will currently not work -- it will strip the `rest_endpoint` from the URI `/cool-project/model-name/model-id`, when the expected internal path is `/model-name/model-id`.

Note that using a `rest_endpoint` of `/cool-project/api/1.0` will also not work -- Symfony will not route this correctly due to the script_alias/request_uri interaction from above.