### PR TITLE
Rely on model's `isDirty()` over `getState()`

### DIFF
--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -503,7 +503,7 @@ class Store
             // Deletes must execute before updates to prevent an update then a delete.
             $this->doCommitDelete($model);
 
-        } elseif (true === $model->getState()->is('dirty')) {
+        } elseif (true === $model->isDirty()) {
             $this->doCommitUpdate($model);
 
         } else {
@@ -628,7 +628,7 @@ class Store
     protected function shouldCommit(Model $model)
     {
         $state = $model->getState();
-        return true === $state->is('dirty') || $state->is('new') || $state->is('deleting');
+        return $model->isDirty() || $state->is('new') || $state->is('deleting');
     }
 
     /**


### PR DESCRIPTION
The `getState()->is('dirty')` method only updates when changes are made directly to the owning model, and does not recognize changes made on ancestor embedded models. The `isDirty()` check, however, does not have this problem because it actively introspects ancestor embeds via `hasOneEmbeds->areDirty()` and `hasManyEmbeds->areDirty()`.

As such, the `Store` needs to use this method when determining when to update the model, otherwise changes to ancestor embeds may not be committed.